### PR TITLE
reconfigured class

### DIFF
--- a/binomialRF/binomialRF.py
+++ b/binomialRF/binomialRF.py
@@ -8,10 +8,11 @@ import numpy as np
 import structure_dt as stdt
 import graphs
 import random
-#from libc.math cimport log as clog
-#from libc.math cimport exp
-#cimport numpy as cnp
-#cimport cython
+
+# from libc.math cimport log as clog
+# from libc.math cimport exp
+# cimport numpy as cnp
+# cimport cython
 
 # evaluate random forest ensemble for regression
 
@@ -31,92 +32,106 @@ import scipy.stats as st
 import statsmodels.stats.multitest as correct
 
 
-
 class binomialRF:
     """binomialRF: a correlated binomial process to select features using
     random forests. Requires sci-kit learn's random forest implementation.
-    
+
     binomialRF.py is a python implementation of Rachid Zaim's binomialRF:
         https://github.com/SamirRachidZaim/binomialRF,
         https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-020-03718-9
-        
+
     Feature selection uses a correlation adjustment to treat for data-dependence
-    on trees, and is used to develop a p-value-based ranking for features in 
-    a random forest classifier. 
-    
+    on trees, and is used to develop a p-value-based ranking for features in
+    a random forest classifier.
+
     Parameters:
     -----------
-    
+
     X : data.frame or array
-        The predictor matrix for which one wants to learn the features' 
-        significance. 
+        The predictor matrix for which one wants to learn the features'
+        significance.
 
     y : the label/outcome vector
         The y vector used to label the instances/observations in the
-        design/predictor matrix, X. 
-    
-    
+        design/predictor matrix, X.
+
+
     ntrees : integer, greater than zero
         The (maximum) number of trees to build in fitting the model.  We
         highly recommend using early stopping rather than guesswork or
         grid search to set this parameter.
-    
+
     subsample : float, default is .3
         The percentage of cases sampled by each decision tree to train each
-        weak learner in the random forest classifier. 
-    
-    
+        weak learner in the random forest classifier.
+
+
     References:
     -----------
-    Rachid Zaim, S., Kenost, C., Berghout, J. et al. binomialRF: 
-    interpretable combinatoric efficiency of random forests to 
-    identify biomarker interactions. BMC Bioinformatics 21, 374 
+    Rachid Zaim, S., Kenost, C., Berghout, J. et al. binomialRF:
+    interpretable combinatoric efficiency of random forests to
+    identify biomarker interactions. BMC Bioinformatics 21, 374
     (2020). https://doi.org/10.1186/s12859-020-03718-9
 
 
 
     """
-    
-    def __init__(self, X, y, ntrees, subsample):
-        self.X = X
-        self.y = y
-        self.ntrees = ntrees
-        self.subsample= subsample
-    
-    def fit_model(self):
 
-        model = BaggingClassifier(base_estimator=DecisionTreeClassifier(), max_samples=self.subsample, n_estimators=self.ntrees)
-        fitted_model = model.fit(self.X,self.y)
-        
-        return fitted_model
-    
-    
-    def get_main_effects(self, rf_model):
-        
-        features= [[tree.tree_.feature[0]] for j,tree in enumerate(rf_model.estimators_)]
+    def __init__(self, model):
+        self.model = model
+        self.subsample = model.get_param()["max_samples"]
+        self.ntrees = model.get_param()["n_estimators"]
+
+    def fit(self, X: pd.DataFrame, y):
+        self.feature_length = len(X.columns)
+        self.model.fit(X, y)
+
+        return self.model
+
+    def get_main_effects(self):
+
+        features = [
+            [tree.tree_.feature[0]] for j, tree in enumerate(self.model.estimators_)
+        ]
         df = pd.Series(data=features)
 
         ## calculate frequency of forot split vars
-        main_effects_counts = df.value_counts().rename_axis('feature').reset_index(name='TestStatistic')
-        return(main_effects_counts)
-    
-    def calculate_naive_pvalue(self, main_effects_counts): 
-        main_effects_counts['pvalues'] = [st.binom_test(x, 20, 1/20, alternative='greater') for x in main_effects_counts.TestStatistic]
-        fdrs = correct.fdrcorrection(main_effects_counts.pvalues,  method='negcorr' )[1]
-        main_effects_counts['FDR']= fdrs
-        return(main_effects_counts)
+        main_effects_counts = (
+            df.value_counts().rename_axis("feature").reset_index(name="TestStatistic")
+        )
+        return main_effects_counts
+
+    def calculate_naive_pvalue(self):
+        main_effects_counts = self.get_main_effects()
+
+        main_effects_counts["pvalues"] = [
+            st.binom_test(x, 20, 1 / 20, alternative="greater")
+            for x in main_effects_counts.TestStatistic
+        ]
+        fdrs = correct.fdrcorrection(main_effects_counts.pvalues, method="negcorr")[1]
+        main_effects_counts["FDR"] = fdrs
+
+        return main_effects_counts
 
     def calculate_cbinom(self):
-        correlbinom = importr('correlbinom')
+        correlbinom = importr("correlbinom")
 
-        ncols= len(self.X.columns)
+        ncols = self.feature_length
         success_prob = 1 / ncols
-        cbinom= correlbinom.correlbinom(self.subsample, success_prob, self.ntrees)
+        cbinom = correlbinom.correlbinom(self.subsample, success_prob, self.ntrees)
+
         return cbinom
 
-    def calculate_correlated_pvalues(self, main_effects_counts, cbinom):
-        main_effects_counts['correl_pvalue'] = [1-np.sum(cbinom[0:x]) for x in main_effects_counts.TestStatistic]
-        fdrs = correct.fdrcorrection(main_effects_counts.correl_pvalue,  method='negcorr' )[1]
-        main_effects_counts['FDR']= fdrs
+    def calculate_correlated_pvalues(self):
+        cbinom = self.calculate_cbinom()
+        main_effects_counts = self.get_main_effects()
+
+        main_effects_counts["correl_pvalue"] = [
+            1 - np.sum(cbinom[0:x]) for x in main_effects_counts.TestStatistic
+        ]
+        fdrs = correct.fdrcorrection(
+            main_effects_counts.correl_pvalue, method="negcorr"
+        )[1]
+        main_effects_counts["FDR"] = fdrs
+
         return main_effects_counts
-  


### PR DESCRIPTION
Changed a few things in the class to make better use of Python's classes. Some random changes throughout were caused by the "black" formatter which matches PEP8 python code formatting standards.

Changes:

-     __init__() - instead of setting the X and y, which are really only used in the fit() method, pass in the model object, this way you can interchangeably find feature importance for any type of RandomForest classes
-     fit() - pass in the X and y dataframes here instead of the model. Also create a new attribute "feature_length" that can be called in the calculate_cbinom() method
-     get_main_effects() this has changed slightly, since the model itself is now an attribute, instead of passing the model object, the method just calls self.model wherever it is needed.
-     calculate_naive_pvalue() now calls get_main_effects() at the top of the method so you don't have to pass it the main_effects
-     calculate_cbinom() now uses the new attribute feature_length instead of the self.X
-     calculate_correlated_pvalue() calls calculate_cbinom and calculate_main_effects() at the top